### PR TITLE
SVG logo in docs, circumvent CDN cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![Wetland](https://cdn.rawgit.com/SpoonX/wetland/master/wetland.svg)
+# ![Wetland](https://cdn.rawgit.com/SpoonX/wetland/391040eba795183550bfff01d7c0ca56d01b5530/wetland.svg)
 
 [![Build Status](https://travis-ci.org/SpoonX/wetland.svg?branch=master)](https://travis-ci.org/SpoonX/wetland)
 [![npm version](https://badge.fury.io/js/wetland.svg)](https://badge.fury.io/js/wetland)

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,4 +1,4 @@
-# ![Wetland](https://cloud.githubusercontent.com/assets/67802/19230467/ed74d496-8ed4-11e6-84bf-4bcc7c5c2fef.png)
+# ![Wetland](https://cdn.rawgit.com/SpoonX/wetland/master/wetland.svg)
 
 Wetland is an enterprise grade object-relational mapper (ORM) for node.js.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,4 +1,4 @@
-# ![Wetland](https://cdn.rawgit.com/SpoonX/wetland/master/wetland.svg)
+# ![Wetland](https://cdn.rawgit.com/SpoonX/wetland/391040eba795183550bfff01d7c0ca56d01b5530/wetland.svg)
 
 Wetland is an enterprise grade object-relational mapper (ORM) for node.js.
 


### PR DESCRIPTION
Change docs logo to SVG as well, and change the URL used to circumvent the CDN cache.