### PR TITLE
Fix entityPath resolution and support ES6 default export

### DIFF
--- a/src/Wetland.ts
+++ b/src/Wetland.ts
@@ -82,7 +82,7 @@ export class Wetland {
         .filter(match => match.search(/\.js$/) > -1)
         .map(entity => entity.replace(/\.js$/, ''))
         .forEach(entity => {
-          let filePath   = path.join(entityPath, entity);
+          let filePath   = path.resolve(entityPath, entity);
           let ToRegister = require(filePath);
 
           if (typeof ToRegister !== 'function') {

--- a/src/Wetland.ts
+++ b/src/Wetland.ts
@@ -82,11 +82,16 @@ export class Wetland {
         .filter(match => match.search(/\.js$/) > -1)
         .map(entity => entity.replace(/\.js$/, ''))
         .forEach(entity => {
-          let filePath   = path.resolve(entityPath, entity);
-          let ToRegister = require(filePath);
+          let filePath     = path.resolve(entityPath, entity);
+          let entityModule = require(filePath);
+          let ToRegister   = entityModule;
 
           if (typeof ToRegister !== 'function') {
-            ToRegister = ToRegister[entity];
+            ToRegister = entityModule.default;
+          }
+
+          if (typeof ToRegister !== 'function') {
+            ToRegister = entityModule[entity];
           }
 
           if (typeof ToRegister !== 'function') {


### PR DESCRIPTION
This PR
- fixes `entityPath` path resolution (`path.join` strips `./` prefixes from relative paths)
- adds support for entities `export`ed as `default` from an ES6 module