### PR TITLE
fix(populator): adding null property check

### DIFF
--- a/src/Populate.ts
+++ b/src/Populate.ts
@@ -49,7 +49,7 @@ export class Populate {
         return options.populate.add({[property]: property});
       }
 
-      if (typeof data[property] !== 'object') {
+      if (typeof data[property] !== 'object' || data[property] === null) {
         return;
       }
 


### PR DESCRIPTION
One problem I have using sails-hook-wetland is that on entity update the content of the request is given to the `findDataForUpdate()` as the third argument. A bug happened when in the object there is a property which holds `null`. 
`TypeError: Cannot read property 'id' of null` is the error thrown. It's easily explainable : at this stage the check for non object didn't fire because `null` is an object and then in the following check it's trying to read a property of null. 