### PR TITLE
Seeder

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -6,6 +6,7 @@
 * [Quick Start](quick-start.md)
 * [Edge cases](edge-cases.md)
 * [Entity](entity.md)
+* [Seeding](seeding.md)
 * [Changelog](CHANGELOG.md)
 * [License](LICENSE.md)
 

--- a/doc/seeding.md
+++ b/doc/seeding.md
@@ -39,3 +39,59 @@ The no lifecycle mode means that feature will not go through the lifecyles befor
 
 Everything must be in a single folder, subfolder are not supported for the moment.
 The name of the file **must** be the name of the entity, the extension **must** either be `csv` or `json`.
+
+### Config
+
+The seeder has to be configured.
+
+```js
+const config = {
+  seed         : {
+    fixturesDirectory   : 'fixtures', // Each filename is an entity
+    bypassLifecyclehooks: true,
+    clean               : false
+  },
+  entities     : []
+}
+```
+
+## The code
+
+If you want to use the seeder you must ask wetland to give you one.
+
+```js
+const seeder = wetland.getSeeder();
+```
+
+### Clean seeding
+
+If you do clean seeding you should use the seeder like this :
+
+```js
+const migrator = wetland.getMigrator();
+const seeder = wetland.getSeeder();
+
+seeder.clean() // Will clean the database, NO MAGICAL GOING BACK
+          .then(() => migrator.devMigrations(false)) // Will actually do the migrations : needed here because the clean method wipes the database entirely
+          .then(() => seeder.seed()) // Will seed accordingly to the configuration you gave wetland
+```
+
+## Safe seeding
+
+If you want to do safe seeding you should use the seeder like this :
+
+```js
+const migrator = wetland.getMigrator();
+const seeder = wetland.getSeeder();
+
+migrator.devMigrations(false) // Will migrate the database
+          .then(() => seeder.seed()) // Will seed accordingly to the configuration you gave wetland
+```
+
+All of the above assume you are using the seeder in the dev environment : most likely the most common use case would be tests and dev setup (seeding your database some data for development). But you could chose to use it for production but then most likely you want to stay safe and not use dev migrations effectively just doing this :
+
+```js
+const seeder = wetland.getSeeder();
+
+seeder.seed()
+```

--- a/doc/seeding.md
+++ b/doc/seeding.md
@@ -1,0 +1,41 @@
+# Seeding
+
+Seeding consist in populating the database from fixtures.
+
+## Types of seeding
+
+Wetland supports $$2^2 = 4$$ modes of seeding.
+
+## Safe or clean
+
+### Safe
+
+Safe seeding refers to the concept of verifying if a record already exist before seeding it, there's little risk associated with it that's why we call it safe seeding...
+
+### Clean
+Clean seeding refers to the concept of clearing the database before seeding.
+
+## Lifecycle or no lifecycle
+
+### Lifecycle
+
+The lifecycle mode means that features will go through the lifecycles before being inserted : that's the default mode.
+
+## No lifecyle
+
+The no lifecycle mode means that feature will not go through the lifecyles before being inserted.
+
+
+## Setup
+
+### Fixtures directory and file type support
+
+```
+└── fixtures 
+    ├── User.json
+    ├── Pet.csv
+    └── Entity.extension
+```
+
+Everything must be in a single folder, subfolder are not supported for the moment.
+The name of the file **must** be the name of the entity, the extension **must** either be `csv` or `json`.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,8 @@ const gulp = require('gulp');
 
 gulp.task('build', ['copyFiles']);
 gulp.task('copyFiles', () => {
-  gulp.src(['./src/**/*', '!./**/*.ts']).pipe(gulp.dest('dist/src'))
+  gulp.src(['./test/resource/fixtures/**/**/*']).pipe(gulp.dest('dist/test/resource/fixtures/'));
+  gulp.src(['./src/**/*', '!./**/*.ts']).pipe(gulp.dest('dist/src'));
 });
 
-gulp.task('watch', ['build'], () => gulp.watch(['./src/**/*', '!./**/*.ts'], ['build']));
+gulp.task('watch', ['build'], () => gulp.watch(['./src/**/*', '!./**/*.ts', './test/resource/fixtures/**/**/*'], ['build']));

--- a/package.json
+++ b/package.json
@@ -33,9 +33,11 @@
   "homepage": "https://wetland.spoonx.org",
   "dependencies": {
     "bluebird": "^3.4.6",
+    "csv-parse": "^1.2.0",
     "homefront": "^1.3.2",
     "knex": "^0.12.6",
     "mkdirp": "^0.5.1",
+    "rimraf": "^2.6.1",
     "stream-replace": "^1.0.0"
   },
   "devDependencies": {

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -119,7 +119,7 @@ export class Scope {
    *
    * @returns {EntityInterface|null}
    */
-  public resolveEntityReference(hint: Entity): {new ()} {
+  public resolveEntityReference(hint: Entity): { new () } {
     return this.manager.resolveEntityReference(hint);
   }
 
@@ -206,7 +206,7 @@ export class Scope {
    *
    * @returns {{}}
    */
-  public getEntities(): {[key: string]: {entity: EntityCtor<EntityInterface>, mapping: Mapping<EntityInterface>}} {
+  public getEntities(): { [key: string]: { entity: EntityCtor<EntityInterface>, mapping: Mapping<EntityInterface> } } {
     return this.manager.getEntities();
   }
 
@@ -270,8 +270,8 @@ export class Scope {
    *
    * @return {Promise}
    */
-  public flush(skipClean: boolean = false): Promise<any> {
-    return this.unitOfWork.commit(skipClean);
+  public flush(skipClean: boolean = false, skipLifecyclehooks: boolean = false): Promise<any> {
+    return this.unitOfWork.commit(skipClean, skipLifecyclehooks);
   }
 
   /**
@@ -286,4 +286,4 @@ export class Scope {
   }
 }
 
-export type Entity = string | {new ()} | EntityInterface;
+export type Entity = string | { new () } | EntityInterface;

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -268,6 +268,9 @@ export class Scope {
    * This means calculating changes to make, as well as the order to do so.
    * One of the things involved in this is making the distinction between stores.
    *
+   * @param {boolean} skipClean
+   * @param {boolean} skipLifecyclehooks
+   *
    * @return {Promise}
    */
   public flush(skipClean: boolean = false, skipLifecyclehooks: boolean = false): Promise<any> {

--- a/src/Seeder.ts
+++ b/src/Seeder.ts
@@ -3,13 +3,12 @@ import {Store} from './Store';
 import {Homefront} from 'homefront';
 import {EntityCtor} from "./EntityInterface";
 import {ArrayCollection} from "./ArrayCollection";
-const fs     = require('fs');
-const rimraf = require('rimraf');
-const parse  = require("csv-parse");
+import * as fs from 'fs';
+import * as rimraf from 'rimraf';
+import * as parse  from "csv-parse";
 import * as path from "path";
 import * as Bluebird from 'bluebird';
-import {Mapping} from "./Mapping";
-import {Entity} from "./Entity";
+import {Mapping} from "./Mapping";  
 import {UnitOfWork} from "./UnitOfWork";
 
 export class Seeder {

--- a/src/Seeder.ts
+++ b/src/Seeder.ts
@@ -1,0 +1,245 @@
+import {Wetland} from './Wetland';
+import {Store} from './Store';
+import {Homefront} from 'homefront';
+import {EntityCtor} from "./EntityInterface";
+import {ArrayCollection} from "./ArrayCollection";
+const fs     = require('fs');
+const rimraf = require('rimraf');
+const parse  = require("csv-parse");
+import * as path from "path";
+import * as Bluebird from 'bluebird';
+import {Mapping} from "./Mapping";
+import {Entity} from "./Entity";
+import {UnitOfWork} from "./UnitOfWork";
+
+export class Seeder {
+
+  config: Homefront = new Homefront();
+
+  wetland: Wetland;
+
+  constructor(wetland: Wetland) {
+    this.wetland = wetland;
+    this.config  = this.config.merge(wetland.getConfig().fetch('seed'));
+  }
+
+  /**
+   * Clean the data directory.
+   *
+   * @return {Promise<any>}
+   */
+  private cleanDirectory(): Promise<any> {
+    const rmDir: any = Bluebird.promisify(rimraf);
+
+    return rmDir(this.wetland.getConfig().fetch('dataDirectory'));
+  }
+
+  /**
+   * Reset database.
+   *
+   * @param store
+   * @return {Promise<any>}
+   */
+  private resetDatabase(store: Store): Promise<any> {
+    const knex     = require('knex')(store);
+    const database = store.getConnections()[Store.ROLE_MASTER].database;
+
+    return knex.raw(`DROP DATABASE IF EXISTS ${database};`)
+      .then(() => this.cleanDirectory())
+      .then(() => knex.raw(`CREATE DATABASE ${database};`));
+  }
+
+  /**
+   * Reset the embedded database.
+   *
+   * @param store
+   * @return {Promise<any>}
+   */
+  private resetEmbeddedDatabase(store: Store): Promise<any> {
+    let filename = store.getConnections()[Store.ROLE_MASTER].filename;
+
+    if (!fs.existsSync(filename)) {
+      return this.cleanDirectory();
+    }
+
+    const rm: any = Bluebird.promisify(fs.unlink);
+    return rm(filename)
+      .then(this.cleanDirectory());
+  }
+
+  /**
+   * Clean the database and the wetland's data directory.
+   *
+   * @return {Promise<any>}
+   */
+  public clean(): Promise<any> {
+    const store = this.wetland.getStore();
+
+    if (store.getClient() === 'sqlite3') {
+      return this.resetEmbeddedDatabase(store);
+    }
+
+    return this.resetDatabase(store);
+  }
+
+  /**
+   * Bulk features insertion.
+   *
+   * @param {string} entityName
+   * @param {Array<Object>} features
+   * @param {boolean} bypassLifecyclehooks
+   * @return {Promise<any>}
+   */
+  private cleanlyInsertFeatures(entityName: string, features: Array<Object>, bypassLifecyclehooks: boolean): Promise<any> {
+    const manager    = this.wetland.getManager();
+    const unitOfWork = manager.getUnitOfWork();
+    const populator  = this.wetland.getPopulator(manager);
+    const Entity     = manager.getEntity(entityName) as EntityCtor<Function>;
+    const entities   = new ArrayCollection();
+
+    features.forEach(feature => {
+      let entity = populator.assign(Entity, feature);
+
+      unitOfWork.setEntityState(entity, UnitOfWork.STATE_NEW);
+
+      entities.push(entity);
+    });
+
+    return manager.persist(...entities).flush(false, bypassLifecyclehooks);
+  }
+
+  /**
+   * Safe (no duplicate) features insertion going through the lifecylehooks.
+   *
+   * @param {string} entityName
+   * @param {Array<Object>} features
+   * @param {boolean} bypassLifecyclehooks
+   * @return {Promise<any>}
+   */
+  private safelyInsertFeatures(entityName: string, features: Array<Object>, bypassLifecyclehooks: boolean): Promise<any> {
+    const manager          = this.wetland.getManager();
+    const unitOfWork       = manager.getUnitOfWork();
+    const populator        = this.wetland.getPopulator(manager);
+    const Entity           = manager.getEntity(entityName) as EntityCtor<Function>;
+    const correctFields    = Mapping.forEntity(Entity).getFieldNames();
+    const entityRepository = manager.getRepository(Entity);
+
+    const queries = [];
+
+    features.forEach(feature => {
+
+      let target = {};
+
+      Reflect.ownKeys(feature).forEach((field: string) => {
+        if (correctFields.includes(field)) {
+          target[field] = feature[field];
+        }
+      });
+
+      queries.push(entityRepository.findOne(target).then(response => {
+        if (!response) {
+          let populated = populator.assign(Entity, feature);
+
+          unitOfWork.setEntityState(populated, UnitOfWork.STATE_NEW);
+
+          return Promise.resolve(populated);
+        }
+
+        return Promise.resolve(null);
+      }));
+    });
+
+    return Promise.all(queries).then((entities) => {
+      entities = entities.filter(e => e != null);
+
+      if (!entities.length) {
+        return Promise.resolve();
+      }
+
+      return manager.persist(...entities).flush(false, bypassLifecyclehooks);
+    });
+  }
+
+  /**
+   * Seed features according to options.
+   *
+   * @param {string} entityName
+   * @param {Array<Object>} features
+   * @param {boolean} clean
+   * @param {boolean} bypassLifecyclehooks
+   * @return {Promise<any>}
+   */
+  private seedFeatures(entityName: string, features: Array<Object>, clean: boolean, bypassLifecyclehooks: boolean): Promise<any> {
+    if (clean) {
+      return this.cleanlyInsertFeatures(entityName, features, bypassLifecyclehooks);
+    }
+
+    return this.safelyInsertFeatures(entityName, features, bypassLifecyclehooks);
+  }
+
+  /**
+   * Seed from file.
+   *
+   * @param {string} src
+   * @param {string} file
+   * @param {boolean} clean
+   * @param {boolean} bypassLifecyclehooks
+   * @return {Promise<any>}
+   */
+  private seedFile(src: string, file: string, clean: boolean, bypassLifecyclehooks: boolean): Promise<any> {
+    const readFile: any = Bluebird.promisify(fs.readFile);
+
+    return readFile(path.join(src, file), 'utf8')
+      .then(data => {
+        let [entityName, extension] = file.split('.'); // Very naive **might** need better
+
+        if (extension === 'json') {
+          let features = JSON.parse(data);
+
+          return this.seedFeatures(entityName, features, clean, bypassLifecyclehooks);
+        }
+
+        if (extension === 'csv') {
+          const parseP: any = Bluebird.promisify(parse);
+
+          return parseP(data, {columns: true})
+            .then(features => this.seedFeatures(entityName, features, clean, bypassLifecyclehooks));
+        }
+
+        return Promise.resolve();
+      });
+  }
+
+  /**
+   * Seed files contained in the fixtures directory.
+   *
+   * @return {Promise}
+   */
+  public seed(): Promise<any> {
+    if (!this.config) {
+      return Promise.reject(new Error('Seed configuration is not valid.'));
+    }
+
+    const fixturesDirectory = this.config.fetch('fixturesDirectory');
+
+    if (!fixturesDirectory) {
+      return Promise.reject(new Error('Seed configuration is not complete.'))
+    }
+
+    const bypassLifecyclehooks = this.config.fetchOrPut('bypassLifecyclehooks', false);
+    const clean                = this.config.fetchOrPut('clean', false);
+
+    const readDir: any = Bluebird.promisify(fs.readdir);
+
+    return readDir(fixturesDirectory)
+      .then(files => {
+        const readers = [];
+
+        files.forEach(file => {
+          readers.push(this.seedFile(fixturesDirectory, file, clean, bypassLifecyclehooks));
+        });
+
+        return Promise.all(readers);
+      });
+  }
+}

--- a/src/Seeder.ts
+++ b/src/Seeder.ts
@@ -1,15 +1,15 @@
 import {Wetland} from './Wetland';
 import {Store} from './Store';
 import {Homefront} from 'homefront';
-import {EntityCtor} from "./EntityInterface";
-import {ArrayCollection} from "./ArrayCollection";
+import {EntityCtor} from './EntityInterface';
+import {ArrayCollection} from './ArrayCollection';
 import * as fs from 'fs';
 import * as rimraf from 'rimraf';
-import * as parse  from "csv-parse";
-import * as path from "path";
+import * as parse  from 'csv-parse';
+import * as path from 'path';
 import * as Bluebird from 'bluebird';
-import {Mapping} from "./Mapping";  
-import {UnitOfWork} from "./UnitOfWork";
+import {Mapping} from './Mapping';
+import {UnitOfWork} from './UnitOfWork';
 
 export class Seeder {
 

--- a/src/UnitOfWork.ts
+++ b/src/UnitOfWork.ts
@@ -100,7 +100,7 @@ export class UnitOfWork {
   /**
    * @type {Array}
    */
-  private afterCommit: Array<{target: EntityInterface, method: string}> = [];
+  private afterCommit: Array<{ target: EntityInterface, method: string }> = [];
 
   /**
    * Create a new UnitOfWork.
@@ -188,7 +188,7 @@ export class UnitOfWork {
   }
 
   /**
-   * returns as provided entity is clean
+   * Returns as provided entity is clean
    *
    * @param {EntityInterface} entity
    *
@@ -199,7 +199,7 @@ export class UnitOfWork {
   }
 
   /**
-   * returns if provided entity is dirty.
+   * Returns if provided entity is dirty.
    *
    * @param {EntityInterface} entity
    *
@@ -306,7 +306,7 @@ export class UnitOfWork {
   }
 
   /**
-   * set the state of an entity.
+   * Set the state of an entity.
    *
    * @param {ProxyInterface} entity
    * @param {string}          state
@@ -425,7 +425,7 @@ export class UnitOfWork {
   }
 
   /**
-   * prepare the cascades for provided entity.
+   * Prepare the cascades for provided entity.
    *
    * @param {EntityInterface} entity
    *
@@ -468,7 +468,7 @@ export class UnitOfWork {
   }
 
   /**
-   * prepare cascades for a single entity.
+   * Prepare cascades for a single entity.
    *
    * @param {EntityInterface} entity
    * @param {string}          property
@@ -507,7 +507,7 @@ export class UnitOfWork {
   }
 
   /**
-   * prepare cascades for all staged changes.
+   * Prepare cascades for all staged changes.
    *
    * @returns {UnitOfWork}
    */
@@ -552,12 +552,12 @@ export class UnitOfWork {
    *
    * @returns {Promise<UnitOfWork>}
    */
-  public commit(skipClean: boolean = false): Promise<any> {
+  public commit(skipClean: boolean = false, skipLifecyclehooks: boolean = false): Promise<any> {
     this.prepareCascades();
 
-    return this.insertNew()
-      .then(() => this.updateDirty())
-      .then(() => this.deleteDeleted())
+    return this.insertNew(skipLifecyclehooks)
+      .then(() => this.updateDirty(skipLifecyclehooks))
+      .then(() => this.deleteDeleted(skipLifecyclehooks))
       .then(() => this.updateRelationships())
       .then(() => this.commitOrRollback(true))
       .then(() => this.processAfterCommit())
@@ -631,7 +631,7 @@ export class UnitOfWork {
   }
 
   /**
-   * rollback previously applied IDs.
+   * Rollback previously applied IDs.
    *
    * @returns {UnitOfWork}
    */
@@ -690,7 +690,7 @@ export class UnitOfWork {
   }
 
   /**
-   * clear the state for provided entity.
+   * Clear the state for provided entity.
    *
    * @param {EntityInterface} entity
    * EntityInterface
@@ -793,14 +793,12 @@ export class UnitOfWork {
    *
    * @returns {Promise<any>}
    */
-  private insertNew(): Promise<any> {
+  private insertNew(skipLifecyclehooks: boolean = false): Promise<any> {
 
     return this.persist(this.newObjects, <T>(queryBuilder: QueryBuilder<T>, target: T & ProxyInterface) => {
-      let mapping    = Mapping.forEntity(target);
-      let primaryKey = mapping.getPrimaryKey();
-
-      return this.lifecycleCallback('create', target)
-        .then(() => queryBuilder.insert(target, primaryKey).getQuery().execute())
+      let mapping     = Mapping.forEntity(target);
+      let primaryKey  = mapping.getPrimaryKey();
+      let insertQuery = queryBuilder.insert(target, primaryKey).getQuery().execute()
         .then(result => {
           if (target.isEntityProxy) {
             target[primaryKey] = {_skipDirty: result[0]};
@@ -810,6 +808,13 @@ export class UnitOfWork {
             target[primaryKey] = result[0];
           }
         });
+
+      if (skipLifecyclehooks) {
+        return insertQuery;
+      }
+
+      return this.lifecycleCallback('create', target)
+        .then(() => insertQuery);
     });
   }
 
@@ -818,7 +823,7 @@ export class UnitOfWork {
    *
    * @returns {Promise<any>}
    */
-  private updateDirty(): Promise<any> {
+  private updateDirty(skipLifecyclehooks: boolean = false): Promise<any> {
     return this.persist(this.dirtyObjects, <T>(queryBuilder: QueryBuilder<T>, target: T) => {
       let dirtyProperties = MetaData.forInstance(target).fetch(`entityState.dirty`, []);
       let targetMapping   = Mapping.forEntity(target);
@@ -831,8 +836,14 @@ export class UnitOfWork {
         });
       }
 
+      let updateQuery = queryBuilder.update(newValues).where({[primaryKey]: target[primaryKey]}).getQuery().execute();
+
+      if (skipLifecyclehooks) {
+        return updateQuery;
+      }
+
       return this.lifecycleCallback('update', target, newValues)
-        .then(() => queryBuilder.update(newValues).where({[primaryKey]: target[primaryKey]}).getQuery().execute());
+        .then(() => updateQuery);
     });
   }
 
@@ -841,19 +852,25 @@ export class UnitOfWork {
    *
    * @returns {Promise<any>}
    */
-  private deleteDeleted(): Promise<any> {
+  private deleteDeleted(skipLifecyclehooks: boolean = false): Promise<any> {
     return this.persist(this.deletedObjects, <T>(queryBuilder: QueryBuilder<T>, target: T & EntityProxy) => {
       let primaryKey = Mapping.forEntity(target).getPrimaryKeyField();
 
       // @todo Use target's mapping to delete relations for non-cascaded properties.
 
+      let deleteQuery = queryBuilder.remove().where({[primaryKey]: target[primaryKey]}).getQuery().execute();
+
+      if (skipLifecyclehooks) {
+        return deleteQuery;
+      }
+
       return this.lifecycleCallback('remove', target, this.deletedObjects)
-        .then(() => queryBuilder.remove().where({[primaryKey]: target[primaryKey]}).getQuery().execute());
+        .then(() => deleteQuery);
     });
   }
 
   /**
-   * apply relationship changes in the database.
+   * Apply relationship changes in the database.
    *
    * @returns {Promise<{}>}
    */
@@ -973,7 +990,7 @@ export class UnitOfWork {
    *
    * @returns {UnitOfWork}
    */
-  public clear(...entities: Array<EntityInterface|ProxyInterface>): UnitOfWork {
+  public clear(...entities: Array<EntityInterface | ProxyInterface>): UnitOfWork {
     (entities.length ? entities : this.newObjects).forEach(created => this.clearEntityState(created));
     (entities.length ? entities : this.deletedObjects).forEach(deleted => this.clearEntityState(deleted));
     (entities.length ? entities : this.cleanObjects).forEach(clean => this.clearEntityState(clean));

--- a/src/UnitOfWork.ts
+++ b/src/UnitOfWork.ts
@@ -550,6 +550,9 @@ export class UnitOfWork {
   /**
    * Commit the current state.
    *
+   * @param {boolean} skipClean
+   * @param {boolean} skipLifecyclehooks
+   *
    * @returns {Promise<UnitOfWork>}
    */
   public commit(skipClean: boolean = false, skipLifecyclehooks: boolean = false): Promise<any> {
@@ -791,6 +794,8 @@ export class UnitOfWork {
   /**
    * Persist new entities.
    *
+   * @param {boolean} skipLifecyclehooks
+   *
    * @returns {Promise<any>}
    */
   private insertNew(skipLifecyclehooks: boolean = false): Promise<any> {
@@ -821,6 +826,8 @@ export class UnitOfWork {
   /**
    * Update dirty entities.
    *
+   * @param {boolean} skipLifecyclehooks
+   *
    * @returns {Promise<any>}
    */
   private updateDirty(skipLifecyclehooks: boolean = false): Promise<any> {
@@ -849,6 +856,8 @@ export class UnitOfWork {
 
   /**
    * Delete removed entities from the database.
+   *
+   * @param {boolean} skipLifecyclehooks
    *
    * @returns {Promise<any>}
    */

--- a/src/Wetland.ts
+++ b/src/Wetland.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import {SnapshotManager} from './SnapshotManager';
 import {SchemaManager} from './SchemaManager';
 import {Populate} from './Populate';
+import {Seeder} from "./Seeder";
 
 export class Wetland {
   /**
@@ -217,6 +218,15 @@ export class Wetland {
     }
 
     return store;
+  }
+
+  /**
+   * Get a seeder.
+   *
+   * @return {Seeder}
+   */
+  public getSeeder(): Seeder {
+    return new Seeder(this);
   }
 
   /**

--- a/test/resource/fixtures/lifecycle/Pet.csv
+++ b/test/resource/fixtures/lifecycle/Pet.csv
@@ -1,0 +1,4 @@
+name
+Kyle
+Jill
+Jullia

--- a/test/resource/fixtures/lifecycle/Post.json
+++ b/test/resource/fixtures/lifecycle/Post.json
@@ -1,0 +1,10 @@
+[
+  {
+    "title": "Main post",
+    "content": "Content...."
+  },
+  {
+    "title": "Test",
+    "content": "Content...."
+  }
+]

--- a/test/resource/fixtures/lifecycle/User.json
+++ b/test/resource/fixtures/lifecycle/User.json
@@ -1,0 +1,10 @@
+[
+  {
+    "username": "Snowden",
+    "password": "I hate NSA"
+  },
+  {
+    "username": "Sheldon",
+    "password": "I love trains"
+  }
+]

--- a/test/resource/fixtures/nolifecycle/Pet.csv
+++ b/test/resource/fixtures/nolifecycle/Pet.csv
@@ -1,0 +1,4 @@
+id,name
+9,Kyle
+2,Jill
+10,Jullia

--- a/test/resource/fixtures/nolifecycle/Post.json
+++ b/test/resource/fixtures/nolifecycle/Post.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "1",
+    "author": "5",
+    "title": "Main post",
+    "content": "Content...."
+  },
+  {
+    "id": "2",
+    "author": "89",
+    "title": "Test",
+    "content": "Content...."
+  }
+]

--- a/test/resource/fixtures/nolifecycle/User.json
+++ b/test/resource/fixtures/nolifecycle/User.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 5,
+    "posts": [1],
+    "username": "Snowden",
+    "password": "I hate NSA"
+  },
+  {
+    "id": 89,
+    "posts": [2],
+    "username": "Sheldon",
+    "password": "I love trains"
+  }
+]

--- a/test/unit/Seeder.spec.ts
+++ b/test/unit/Seeder.spec.ts
@@ -1,0 +1,198 @@
+import {assert} from 'chai';
+import {Scope} from "../../src/Scope";
+import {Wetland} from '../../src/Wetland';
+import * as path from 'path';
+import * as Bluebird from 'bluebird';
+const rimraf = require('rimraf');
+const parse  = require("csv-parse");
+const fs     = require('fs');
+
+const tmpTestDir  = path.join(__dirname, '../.tmp');
+const dataDir     = `${tmpTestDir}/.data`;
+const fixturesDir = path.join(__dirname, '../resource/fixtures/');
+
+class User {
+  static setMapping(mapping) {
+    mapping.forProperty('id').increments().primary();
+    mapping.forProperty('username').field({type: 'string'});
+    mapping.forProperty('password').field({type: 'string'});
+    mapping.forProperty('posts').oneToMany({targetEntity: Post, mappedBy: 'author'});
+  }
+}
+
+class Post {
+  static setMapping(mapping) {
+    mapping.forProperty('id').increments().primary();
+    mapping.forProperty('title').field({type: 'string'});
+    mapping.forProperty('content').field({type: 'text'});
+    mapping.forProperty('author').manyToOne({targetEntity: User, inversedBy: 'posts'});
+  }
+}
+
+class Pet {
+  static setMapping(mapping) {
+    mapping.forProperty('id').increments().primary();
+    mapping.forProperty('name').field({type: 'string'});
+  }
+}
+
+const getType = (bypassLifecyclehooks: boolean) => bypassLifecyclehooks ? 'nolifecycle' : 'lifecycle';
+
+const getWetland = (clean: boolean, bypassLifecyclehooks: boolean) => {
+  const fileName = `${clean ? 'clean' : 'safe'}-${getType(bypassLifecyclehooks)}.sqlite`;
+  return new Wetland({
+    dataDirectory: `${tmpTestDir}/.data`,
+    stores       : {
+      defaultStore: {
+        client          : 'sqlite3',
+        useNullAsDefault: true,
+        connection      : {
+          filename: `${tmpTestDir}/${fileName}`
+        }
+      }
+    },
+    seed         : {
+      fixturesDirectory   : path.join(fixturesDir, getType(bypassLifecyclehooks)), // Each filename is an entity
+      bypassLifecyclehooks: bypassLifecyclehooks,
+      clean               : clean
+    },
+    entities     : [User, Pet, Post]
+  });
+};
+
+const testUsers = (manager: Scope, clean: boolean, bypassLifecyclehooks: boolean) => {
+  let usersFromFile = require(path.join(fixturesDir, getType(bypassLifecyclehooks), 'User.json'));
+
+  return manager.getRepository(User)
+    .find(null, {populate: ['posts']})
+    .then(users => {
+      assert.lengthOf(users, usersFromFile.length);
+
+      if (bypassLifecyclehooks) {
+        users.forEach(user => {
+          assert.lengthOf(user['posts'], 1);
+        });
+      }
+    });
+};
+
+const testPosts = (manager: Scope, clean: boolean, bypassLifecyclehooks: boolean) => {
+  let postsFromFile = require(path.join(fixturesDir, getType(bypassLifecyclehooks), 'Post.json'));
+
+  return manager.getRepository(Post)
+    .find(null, {populate: ['author']})
+    .then(posts => {
+      assert.lengthOf(posts, postsFromFile.length);
+
+      if (bypassLifecyclehooks) {
+        posts.forEach(post => {
+          assert.isDefined(post['author']);
+        });
+      }
+    });
+};
+
+const testPets = (manager: Scope, clean: boolean, bypassLifecyclehooks: boolean) => {
+  const readFile: any = Bluebird.promisify(fs.readFile);
+
+  return readFile(path.join(fixturesDir, getType(bypassLifecyclehooks), 'Pet.csv'))
+    .then(data => {
+      const parseP: any = Bluebird.promisify(parse);
+      return parseP(data, {columns: true});
+    })
+    .then(petsFromFile => {
+      return manager.getRepository(Pet)
+        .find()
+        .then(pets => {
+          assert.lengthOf(pets, petsFromFile.length);
+        });
+    });
+};
+
+describe('Seeder', () => {
+  beforeEach(() => {
+    const rmDir: any = Bluebird.promisify(rimraf);
+
+    return rmDir(dataDir)
+  });
+
+  describe('CleanSeed', () => {
+    describe('.seed(): no lifecyclehooks', () => {
+      it('Should seed the database', () => {
+        const clean                = true;
+        const bypassLifecyclehooks = true;
+
+        const wetland  = getWetland(clean, bypassLifecyclehooks);
+        const migrator = wetland.getMigrator();
+        const seeder   = wetland.getSeeder();
+        const manager  = wetland.getManager();
+
+        return seeder.clean()
+          .then(() => migrator.devMigrations(false))
+          .then(() => seeder.seed())
+          .then(() => testUsers(manager, clean, bypassLifecyclehooks))
+          .then(() => testPosts(manager, clean, bypassLifecyclehooks))
+          .then(() => testPets(manager, clean, bypassLifecyclehooks));
+      });
+    });
+
+    describe('.clean() : lifecyclehooks', () => {
+      it('Should seed the database', () => {
+        const clean                = true;
+        const bypassLifecyclehooks = false;
+
+        const wetland  = getWetland(clean, bypassLifecyclehooks);
+        const migrator = wetland.getMigrator();
+        const seeder   = wetland.getSeeder();
+        const manager  = wetland.getManager();
+
+        return seeder.clean()
+          .then(() => migrator.devMigrations(false))
+          .then(() => seeder.seed())
+          .then(() => testUsers(manager, clean, bypassLifecyclehooks))
+          .then(() => testPosts(manager, clean, bypassLifecyclehooks))
+          .then(() => testPets(manager, clean, bypassLifecyclehooks));
+      });
+    });
+  });
+
+  describe('SafeSeed', () => {
+    describe('.seed(): no lifecyclehooks', () => {
+      it('Should safely seed the database', () => {
+        const clean                = false;
+        const bypassLifecyclehooks = true;
+
+        const wetland  = getWetland(clean, bypassLifecyclehooks);
+        const migrator = wetland.getMigrator();
+        const seeder   = wetland.getSeeder();
+        const manager  = wetland.getManager();
+
+        return migrator.devMigrations(false)
+          .then(() => seeder.seed())
+          .then(() => seeder.seed()) // Called a second time on purpose
+          .then(() => testUsers(manager, clean, bypassLifecyclehooks))
+          .then(() => testPosts(manager, clean, bypassLifecyclehooks))
+          .then(() => testPets(manager, clean, bypassLifecyclehooks));
+      });
+    });
+
+    describe('.seed(): lifecyclehooks', () => {
+      it('Should safely seed', () => {
+        const clean                = false;
+        const bypassLifecyclehooks = false;
+
+        const wetland  = getWetland(clean, bypassLifecyclehooks);
+        const migrator = wetland.getMigrator();
+        const seeder   = wetland.getSeeder();
+        const manager  = wetland.getManager();
+
+        return migrator.devMigrations(false)
+          .then(() => seeder.seed())
+          .then(() => seeder.seed()) // Called a second time on purpose
+          .then(() => testUsers(manager, clean, bypassLifecyclehooks))
+          .then(() => testPosts(manager, clean, bypassLifecyclehooks))
+          .then(() => testPets(manager, clean, bypassLifecyclehooks));
+      });
+    });
+  });
+});

--- a/test/unit/Seeder.spec.ts
+++ b/test/unit/Seeder.spec.ts
@@ -1,11 +1,11 @@
 import {assert} from 'chai';
-import {Scope} from "../../src/Scope";
+import {Scope} from '../../src/Scope';
 import {Wetland} from '../../src/Wetland';
 import * as path from 'path';
 import * as Bluebird from 'bluebird';
-const rimraf = require('rimraf');
-const parse  = require("csv-parse");
-const fs     = require('fs');
+import * as fs from 'fs';
+import * as rimraf from 'rimraf';
+import * as parse  from 'csv-parse';
 
 const tmpTestDir  = path.join(__dirname, '../.tmp');
 const dataDir     = `${tmpTestDir}/.data`;


### PR DESCRIPTION
Most of the feature is explained in the documentation.
There's a need for a design decision concerning different way to do clean seeding and safe seeding.

Clean seeding
```js
seeder.clean()
          .then(() => migrator.devMigrations(false))
          .then(() => seeder.seed())
```

Safe seeding
```js
migrator.devMigrations(false)
          .then(() => seeder.seed())
```

We could run the migrations after cleaning inside the seeding method but that seems like a bad idea. I think the best thing would be to create some sort of helpers that does part of the job that `sails-hook-wetland` does (run dev migration if needed...) and mix that with seeding.

Reference issue #37.