### PR TITLE
Fix typing for typescript >= 2.4

### DIFF
--- a/src/EntityInterface.ts
+++ b/src/EntityInterface.ts
@@ -20,6 +20,8 @@ export interface EntityInterface {
   beforeRemove?(entityManager: Scope): Promise<any> | void;
 
   afterRemove?(entityManager: Scope): Promise<any> | void;
+
+  [key: string]: any
 }
 
 export interface ProxyInterface extends EntityInterface {
@@ -32,6 +34,8 @@ export interface ProxyInterface extends EntityInterface {
   getTarget?(): EntityInterface;
 
   isProxyingActive?(): boolean;
+
+  [key: string]: any
 }
 
 export type EntityCtor<T> = new (...args: any[]) => T;

--- a/src/EntityRepository.ts
+++ b/src/EntityRepository.ts
@@ -184,7 +184,7 @@ export class EntityRepository<T> {
 
     options.limit = 1;
 
-    return this.find(criteria, options).then(result => result ? result[0] : result);
+    return this.find(criteria, options).then(result => result ? result[0] : null);
   }
 
   /**


### PR DESCRIPTION
A little more than 10 days ago typescript released 2.4 which broke some [stuff](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript).
Wetland is concerned by two major features of this release : **Weak Type Detection** and **Improved inference for generics**.

Weak Type Detection is the feature that broke most stuff (especially tests) : 
Indeed wetland's EntityInterface and ProxyInterface are weak types.
Proposed ways to fix this are : 

1. Declare the properties if they really do exist. **Not a fix here**
2. Add an index signature to the weak type (i.e. [propName: string]: {}). **Chosen fix**
3. Use a type assertion (i.e. opts as Options). **Could be a fix**

I didn't choose the latter because It would mean that people using wetland in typescript would have to use type inference for all their entities whenever they want to use wetland a bit further from usual.

Fix for generics doesn't need explanation.

I'm eager to hear your opinion about this @RWOverdijk.
