### PR TITLE
Fix lifecyclehooks

### DIFF
--- a/test/unit/Lifecyclehooks.spec.ts
+++ b/test/unit/Lifecyclehooks.spec.ts
@@ -1,0 +1,119 @@
+import {assert} from 'chai';
+import {Wetland} from '../../src/Wetland';
+import {EntityCtor} from '../../src/EntityInterface';
+import {Entity} from '../../src/Entity';
+import * as path from 'path';
+import * as Bluebird from 'bluebird';
+import * as rimraf from 'rimraf';
+
+const tmpTestDir = path.join(__dirname, '../.tmp');
+const dataDir    = `${tmpTestDir}/.data`;
+
+class User extends Entity {
+  id;
+
+  username;
+
+  password;
+
+  static setMapping(mapping) {
+    mapping.forProperty('id').increments().primary();
+    mapping.forProperty('username').field({type: 'string'});
+    mapping.forProperty('password').field({type: 'string'});
+  }
+
+  beforeCreate() {
+    this.password = (new Buffer(this.password).toString('base64')); // Do not do that in prod
+  }
+
+  beforeUpdate(values) {
+    values.password = (new Buffer(values.password).toString('base64')); // Do not do that in prod
+  }
+}
+
+function getWetland(name) {
+  return new Wetland({
+    entities     : [User],
+    dataDirectory: `${tmpTestDir}/.data`,
+    stores       : {
+      defaultStore: {
+        useNullAsDefault: true,
+        client          : 'sqlite3',
+        connection      : {
+          filename: `${tmpTestDir}/lifecyclehooks-${name}.sqlite`
+        }
+      }
+    }
+  });
+}
+
+describe('Lifecyclehooks', () => {
+  beforeEach(() => {
+    const rmDir: any = Bluebird.promisify(rimraf);
+
+    return rmDir(dataDir)
+  });
+
+  describe('.beforeCreate()', () => {
+    it('should correctly base64 the password', () => {
+      const wetland        = getWetland('before-create');
+      const manager        = wetland.getManager();
+      const UserRepository = manager.getRepository(User);
+
+      const password   = 'Test';
+      const username   = 'Test';
+      const newUser    = new User;
+      newUser.username = username;
+      newUser.password = password;
+
+      return wetland.getMigrator().devMigrations(false)
+        .then(() => {
+          return manager.persist(newUser)
+            .flush();
+        })
+        .then(() => {
+          return UserRepository.findOne({username});
+        })
+        .then((user: User) => {
+          assert.notEqual(user.password, password);
+          assert.equal(user.password, (new Buffer(password)).toString('base64'));
+        });
+    })
+  });
+
+  describe('.beforeUpdate()', () => {
+    it('should correctly base64 the password', () => {
+      const wetland = getWetland('before-update');
+
+      const manager        = wetland.getManager();
+      const populator      = wetland.getPopulator(manager);
+      const UserRepository = manager.getRepository(manager.getEntity('User') as EntityCtor<Entity>);
+
+      const username        = 'John Doe.';
+      const password        = '123456789';
+      const updatedPassword = 'popopopop';
+      const newUser         = new User;
+      newUser.username      = username;
+      newUser.password      = password;
+
+      return wetland.getMigrator().devMigrations(false)
+        .then(() => {
+          return manager.persist(newUser).flush();
+        })
+        .then(() => {
+          return UserRepository.findOne({username});
+        })
+        .then((user: User) => {
+          user.password = updatedPassword;
+          return manager.flush();
+        })
+        .then(() => {
+          return UserRepository.findOne({username});
+        })
+        .then((user: User) => {
+          assert.notEqual(user.password, updatedPassword);
+          assert.equal(user.password, (new Buffer(updatedPassword)).toString('base64'));
+        });
+    });
+  });
+});


### PR DESCRIPTION
In #200 I introduced a bug which affects lifecyclehooks execution. It resulted in changes commited during thoses hooks not to be saved. I corrected the behavior with this patch and created regression test so that this bug will hopefully not be reintroduced again.
I didn't create a test for the `beforeDelete` method although it was affected (even if the effects would not appear anywhere) because it would be really hard to test and add no value : the lifecylehook would nontheless be executed, only the changes on the data ready to be deleted would not stick...