### PR TITLE
Fix and refactor cleaner

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   "dependencies": {
     "bluebird": "^3.4.6",
     "csv-parse": "^1.2.0",
+    "del": "^3.0.0",
     "homefront": "^1.3.2",
     "knex": "^0.12.6",
     "mkdirp": "^0.5.1",
-    "rimraf": "^2.6.1",
     "stream-replace": "^1.0.0"
   },
   "devDependencies": {
@@ -52,6 +52,7 @@
     "mocha": "^3.0.1",
     "mysql": "^2.11.1",
     "reflect-metadata": "^0.1.3",
+    "rimraf": "^2.6.1",
     "sqlite3": "^3.1.4",
     "typescript": "^2.1.0-dev.20161008"
   }

--- a/src/Cleaner.ts
+++ b/src/Cleaner.ts
@@ -1,0 +1,94 @@
+import {Wetland} from './Wetland';
+import {Connection, Store} from './Store';
+import {SnapshotManager} from './SnapshotManager';
+import * as rm from 'del';
+import * as path from 'path';
+
+export class Cleaner {
+
+  wetland: Wetland;
+
+  /**
+   * Construct a cleaner instance.
+   *
+   * @param {Wetland} wetland
+   */
+  constructor(wetland: Wetland) {
+    this.wetland = wetland;
+  }
+
+  /**
+   * Clean the dev snapshots in the data directory.
+   *
+   * @return {Promise<any>}
+   */
+  private cleanDataDirectory(): Promise<any> {
+    return rm(path.join(this.wetland.getConfig().fetch('dataDirectory'), SnapshotManager.DEV_SNAPSHOTS_PATH, '*'))
+      .catch(error => {
+        if (error.code === 'ENOENT') {
+          return Promise.resolve();
+        }
+
+        return Promise.reject(error);
+      })
+  }
+
+  /**
+   * Generate drop table queries for all wetland's registered entities table name.
+   *
+   * @param {Connection} connection
+   * @return {Array<Promise<any>>}
+   */
+  private generateDropTableQueries(connection: Connection): Array<Promise<any>> {
+    const entities = this.wetland.getManager().getEntities();
+
+    const dropTablesQueries = [];
+
+    Reflect.ownKeys(entities).forEach(entityName => {
+      dropTablesQueries.push(connection.raw(`DROP TABLE IF EXISTS ${entities[entityName].mapping.getTableName()}`));
+    });
+
+    return dropTablesQueries;
+  }
+
+  /**
+   * Drop all tables' entities.
+   *
+   * @param store
+   * @return {Promise<any>}
+   */
+  private dropTables(store: Store): Promise<any> {
+
+    function alterForeignKeyChecks(status: boolean): Promise<any> {
+      if (store.getClient() === 'sqlite3') {
+        let statusText = status ? 'ON' : 'OFF';
+
+        return connection.raw(`PRAGMA foreign_keys=${statusText}`);
+      }
+
+      let statusText = status ? 1 : 0;
+
+      return connection.raw(`SET FOREIGN_KEY_CHECKS=${statusText};`);
+    }
+
+    const disableForeignKeyChecks = (): Promise<any> => alterForeignKeyChecks(false);
+
+    const enableForeignKeyChecks = (): Promise<any> => alterForeignKeyChecks(true);
+
+    const connection = store.getConnection(Store.ROLE_MASTER);
+
+    return disableForeignKeyChecks()
+      .then(() => Promise.all(this.generateDropTableQueries(connection)))
+      .then(() => enableForeignKeyChecks());
+  }
+
+  /**
+   * Clean wetland's related tables and wetland's dev snapshots'.
+   *
+   * @return {Promise<any>}
+   */
+  public clean(): Promise<any> {
+    return this.dropTables(this.wetland.getStore())
+      .then(() => this.cleanDataDirectory());
+  }
+}

--- a/src/Seeder.ts
+++ b/src/Seeder.ts
@@ -1,15 +1,13 @@
 import {Wetland} from './Wetland';
-import {Store} from './Store';
-import {Homefront} from 'homefront';
 import {EntityCtor} from './EntityInterface';
+import {UnitOfWork} from './UnitOfWork';
+import {Mapping} from './Mapping';
 import {ArrayCollection} from './ArrayCollection';
+import {Homefront} from 'homefront';
 import * as fs from 'fs';
-import * as rimraf from 'rimraf';
-import * as parse  from 'csv-parse';
+import * as parse from 'csv-parse';
 import * as path from 'path';
 import * as Bluebird from 'bluebird';
-import {Mapping} from './Mapping';
-import {UnitOfWork} from './UnitOfWork';
 
 export class Seeder {
 
@@ -20,65 +18,6 @@ export class Seeder {
   constructor(wetland: Wetland) {
     this.wetland = wetland;
     this.config  = this.config.merge(wetland.getConfig().fetch('seed'));
-  }
-
-  /**
-   * Clean the data directory.
-   *
-   * @return {Promise<any>}
-   */
-  private cleanDirectory(): Promise<any> {
-    const rmDir: any = Bluebird.promisify(rimraf);
-
-    return rmDir(this.wetland.getConfig().fetch('dataDirectory'));
-  }
-
-  /**
-   * Reset database.
-   *
-   * @param store
-   * @return {Promise<any>}
-   */
-  private resetDatabase(store: Store): Promise<any> {
-    const knex     = require('knex')(store);
-    const database = store.getConnections()[Store.ROLE_MASTER].database;
-
-    return knex.raw(`DROP DATABASE IF EXISTS ${database};`)
-      .then(() => this.cleanDirectory())
-      .then(() => knex.raw(`CREATE DATABASE ${database};`));
-  }
-
-  /**
-   * Reset the embedded database.
-   *
-   * @param store
-   * @return {Promise<any>}
-   */
-  private resetEmbeddedDatabase(store: Store): Promise<any> {
-    let filename = store.getConnections()[Store.ROLE_MASTER].filename;
-
-    if (!fs.existsSync(filename)) {
-      return this.cleanDirectory();
-    }
-
-    const rm: any = Bluebird.promisify(fs.unlink);
-    return rm(filename)
-      .then(this.cleanDirectory());
-  }
-
-  /**
-   * Clean the database and the wetland's data directory.
-   *
-   * @return {Promise<any>}
-   */
-  public clean(): Promise<any> {
-    const store = this.wetland.getStore();
-
-    if (store.getClient() === 'sqlite3') {
-      return this.resetEmbeddedDatabase(store);
-    }
-
-    return this.resetDatabase(store);
   }
 
   /**

--- a/src/SnapshotManager.ts
+++ b/src/SnapshotManager.ts
@@ -19,7 +19,11 @@ export class SnapshotManager {
   /**
    * @type {{}}
    */
-  private config: {snapshotDirectory: string, devSnapshotDirectory: string};
+  private config: { snapshotDirectory: string, devSnapshotDirectory: string };
+
+  public static SNAPSHOTS_PATH: string = 'snapshots';
+
+  public static DEV_SNAPSHOTS_PATH: string = 'dev_snapshots';
 
   /**
    * Construct a new SnapshotManager manager.
@@ -32,8 +36,8 @@ export class SnapshotManager {
 
     let config  = wetland.getConfig();
     this.config = {
-      snapshotDirectory   : path.join(config.fetch('dataDirectory'), 'snapshots'),
-      devSnapshotDirectory: path.join(config.fetch('dataDirectory'), 'dev_snapshots')
+      snapshotDirectory   : path.join(config.fetch('dataDirectory'), SnapshotManager.SNAPSHOTS_PATH),
+      devSnapshotDirectory: path.join(config.fetch('dataDirectory'), SnapshotManager.DEV_SNAPSHOTS_PATH)
     };
 
     this.ensureSnapshotDirectory();

--- a/src/Wetland.ts
+++ b/src/Wetland.ts
@@ -10,7 +10,8 @@ import * as path from 'path';
 import {SnapshotManager} from './SnapshotManager';
 import {SchemaManager} from './SchemaManager';
 import {Populate} from './Populate';
-import {Seeder} from "./Seeder";
+import {Seeder} from './Seeder';
+import {Cleaner} from './Cleaner';
 
 export class Wetland {
   /**
@@ -49,7 +50,7 @@ export class Wetland {
   /**
    * @type {{}}
    */
-  private stores: {[key: string]: Store} = {};
+  private stores: { [key: string]: Store } = {};
 
   /**
    * @type {SchemaManager}
@@ -227,6 +228,15 @@ export class Wetland {
    */
   public getSeeder(): Seeder {
     return new Seeder(this);
+  }
+
+  /**
+   * Get a cleaner.
+   *
+   * @return {Cleaner}
+   */
+  public getCleaner(): Cleaner {
+    return new Cleaner(this);
   }
 
   /**

--- a/test/resource/Seeder.ts
+++ b/test/resource/Seeder.ts
@@ -1,0 +1,42 @@
+import * as path from 'path';
+import * as Bluebird from 'bluebird';
+import * as rimraf from 'rimraf';
+
+export const tmpTestDir  = path.join(__dirname, '../.tmp');
+export const dataDir     = `${tmpTestDir}/.data`;
+export const fixturesDir = path.join(__dirname, '../resource/fixtures/');
+
+export class User {
+  static setMapping(mapping) {
+    mapping.forProperty('id').increments().primary();
+    mapping.forProperty('username').field({type: 'string'});
+    mapping.forProperty('password').field({type: 'string'});
+    mapping.forProperty('posts').oneToMany({targetEntity: Post, mappedBy: 'author'});
+  }
+}
+
+export class Post {
+  static setMapping(mapping) {
+    mapping.forProperty('id').increments().primary();
+    mapping.forProperty('title').field({type: 'string'});
+    mapping.forProperty('content').field({type: 'text'});
+    mapping.forProperty('author').manyToOne({targetEntity: User, inversedBy: 'posts'});
+  }
+}
+
+export class Pet {
+  static setMapping(mapping) {
+    mapping.forProperty('id').increments().primary();
+    mapping.forProperty('name').field({type: 'string'});
+  }
+}
+
+export function getType(bypassLifecyclehooks: boolean): string {
+  return bypassLifecyclehooks ? 'nolifecycle' : 'lifecycle'
+}
+
+export function rmDataDir(): Promise<any> {
+  const rmDir: any = Bluebird.promisify(rimraf);
+
+  return rmDir(dataDir);
+}

--- a/test/unit/Cleaner.spec.ts
+++ b/test/unit/Cleaner.spec.ts
@@ -1,0 +1,83 @@
+import {Wetland} from '../../src/Wetland';
+import {Schema} from '../resource/Schema';
+import * as path from 'path';
+import {tmpTestDir, fixturesDir, getType, User, Pet, Post, rmDataDir} from '../resource/Seeder';
+
+describe('Cleaner', () => {
+  beforeEach(() => rmDataDir());
+
+  describe('.clean() : database', () => {
+    before((done) => {
+      Schema.resetDatabase(done);
+    });
+
+    it('Should clean the database correctly and be able to do the migration', () => {
+      const bypassLifecyclehooks = false;
+
+      const wetland = new Wetland({
+        dataDirectory: `${tmpTestDir}/.data`,
+        stores       : {
+          defaultStore: {
+            client    : 'mysql',
+            connection: {
+              database: 'wetland_test',
+              user    : 'root',
+              password: ''
+            }
+          }
+        },
+        seed         : {
+          fixturesDirectory: path.join(fixturesDir, getType(bypassLifecyclehooks)),
+          clean            : true,
+          bypassLifecyclehooks
+        },
+        entities     : [User, Pet, Post]
+      });
+
+      const seeder   = wetland.getSeeder();
+      const cleaner  = wetland.getCleaner();
+      const migrator = wetland.getMigrator();
+
+      return migrator.devMigrations(false)
+        .then(() => seeder.seed())
+        .then(() => cleaner.clean())
+        .then(() => migrator.devMigrations(false))
+        .then(() => seeder.seed());
+    });
+  });
+
+  describe('.clean() : embedded database', () => {
+    it('Should clean the database correctly and be able to do the migration', () => {
+      const bypassLifecyclehooks = false;
+
+      const wetland = new Wetland({
+        dataDirectory: `${tmpTestDir}/.data`,
+        stores       : {
+          defaultStore: {
+            client          : 'sqlite3',
+            useNullAsDefault: true,
+            connection      : {
+              filename: `${tmpTestDir}/cleaner.sqlite`
+            }
+          }
+        },
+        seed         : {
+          fixturesDirectory: path.join(fixturesDir, getType(bypassLifecyclehooks)),
+          clean            : true,
+          bypassLifecyclehooks
+        },
+        entities     : [User, Pet, Post]
+      });
+
+      const seeder   = wetland.getSeeder();
+      const cleaner  = wetland.getCleaner();
+      const migrator = wetland.getMigrator();
+
+      return migrator.devMigrations(false)
+      .then(() => seeder.seed())
+      .then(() => cleaner.clean())
+      .then(() => migrator.devMigrations(false))
+      .then(() => seeder.seed());
+    });
+  });
+});


### PR DESCRIPTION
Quite a pull request.
The cleaner part of the seeder has been moved into its own class to respect separation of concerns, tests have been added too.
The cleaner which had some bugs was also fixed at the same time.
Most important changes are that : 
* The cleaner now only affects tables referenced by entities by dropping them.
* The cleaner only deletes files inside `.data/dev_snapshots` because there is no reason to delete the entire `.data` directory besides leading to bugs and data loss.

Bugs the cleaner could introduce and that must be discussed :
* It is needed to disable foreign key check before dropping tables but the syntax is vendor dependent : it actually supports sqlite3 and mysql for sure, question is : is there differences in other vendors ?