### PR TITLE
fix(snapshot-manager): Nulleable option in joinColumn fields

### DIFF
--- a/src/SnapshotManager.ts
+++ b/src/SnapshotManager.ts
@@ -516,7 +516,7 @@ export class SnapshotManager {
         // We own the fk.
         let joinColumn = mapping.fields[property].joinColumn;
         let changes    = {
-          field  : {name: joinColumn.name, type: 'integer', unsigned: true, nullable: true},
+          field  : {name: joinColumn.name, type: 'integer', unsigned: true, nullable: (typeof joinColumn.nullable === 'boolean' ? joinColumn.nullable : true)},
           foreign: createForeign(mapping, property, targetMapping)
         };
 

--- a/test/resource/entity/book/book.ts
+++ b/test/resource/entity/book/book.ts
@@ -1,0 +1,22 @@
+import {ArrayCollection} from '../../../../src/ArrayCollection';
+import {Mapping} from '../../../../src/Mapping';
+import {Publisher} from './publisher';
+
+export class Book {
+
+  public id: Number;
+
+  public publisher: ArrayCollection<Publisher>;
+
+  public name: string;
+
+  static setMapping(mapping: Mapping<Book>) {
+    mapping.field('id', {type: 'integer'}).primary('id').generatedValue('id', 'autoIncrement');
+    mapping.field('name', {type: 'string', size: 24});
+
+    mapping
+      .manyToOne('publisher', {targetEntity: 'Publisher', inversedBy: 'books'})
+      .joinColumn('publisher', {nullable: false});
+
+  }
+}

--- a/test/resource/entity/book/publisher.ts
+++ b/test/resource/entity/book/publisher.ts
@@ -1,0 +1,22 @@
+import {ArrayCollection} from '../../../../src/ArrayCollection';
+import {Mapping} from '../../../../src/Mapping';
+import {Book} from './book';
+
+export class Publisher {
+  public id: number;
+
+  public name: string;
+
+  public books: ArrayCollection<Book>;
+
+  static setMapping(mapping: Mapping<Publisher>) {
+    mapping.forProperty('id')
+      .field({type: 'integer'})
+      .generatedValue('autoIncrement')
+      .primary();
+
+    mapping.field('name', {type: 'string', size: 24});
+
+    mapping.oneToMany('books', {targetEntity: 'Book', mappedBy: 'publisher'});
+  }
+}


### PR DESCRIPTION
This is a expected behaviour as the documentation says so.

Solves #215