### PR TITLE
UnitOfWork gives dirty scope to lifecylebacks after methods

### DIFF
--- a/doc/API/unit-of-work.md
+++ b/doc/API/unit-of-work.md
@@ -20,7 +20,7 @@ unitOfWork.cascadeSingle(entity, 'property', entity['property'], mapping);
 
 {% method %}
 ## .clean()
-Marks everything as clean.
+Mark everything as clean, empty transactions and empty after commits.
 
 {% common %}
 ```js

--- a/src/UnitOfWork.ts
+++ b/src/UnitOfWork.ts
@@ -563,10 +563,10 @@ export class UnitOfWork {
       .then(() => this.deleteDeleted(skipLifecycleHooks))
       .then(() => this.updateRelationships())
       .then(() => this.commitOrRollback(true))
-      .then(() => this.processAfterCommit())
       .then(() => this.entityManager.getConfig().fetch('entityManager.refreshUpdated') && this.refreshDirty())
       .then(() => this.entityManager.getConfig().fetch('entityManager.refreshCreated') && this.refreshNew())
       .then(() => !skipClean && this.clean())
+      .then(() => !skipClean && this.processAfterCommit())
       .catch(error => this.commitOrRollback(false, error));
   }
 

--- a/src/UnitOfWork.ts
+++ b/src/UnitOfWork.ts
@@ -565,12 +565,18 @@ export class UnitOfWork {
       .then(() => this.commitOrRollback(true))
       .then(() => this.entityManager.getConfig().fetch('entityManager.refreshUpdated') && this.refreshDirty())
       .then(() => this.entityManager.getConfig().fetch('entityManager.refreshCreated') && this.refreshNew())
-      .then(() => !skipClean && this.clean())
+      .then(() => !skipClean && this.cleanObjectsAndTransactions())
       .then(() => !skipClean && this.processAfterCommit())
+      .then(() => !skipClean && this.cleanAfterCommit())
       .catch(error => this.commitOrRollback(false, error));
   }
 
-  private processAfterCommit() {
+  /**
+   * Execute post commit lifecyle callbacks.
+   *
+   * @return {Promise<Array<Function>>}
+   */
+  private processAfterCommit(): Promise<Array<Function>> {
     let methods = [];
 
     this.afterCommit.forEach(action => {
@@ -1032,11 +1038,22 @@ export class UnitOfWork {
   }
 
   /**
-   * Mark everything as clean.
+   * Empty after commit.
    *
-   * @returns {UnitOfWork}
+   * @return {Promise<void>}
    */
-  public clean(): Promise<void> {
+  private cleanAfterCommit(): Promise<void> {
+    this.afterCommit = [];
+
+    return Promise.resolve();
+  }
+
+  /**
+   * Mark everything as clean and empty transactions.
+   *
+   * @return {Promise<void>}
+   */
+  private cleanObjectsAndTransactions(): Promise<void> {
     this.newObjects.each(created => this.registerClean(created));
     this.dirtyObjects.each(updated => this.registerClean(updated));
     this.relationshipsChangedObjects.each(changed => this.registerClean(changed));
@@ -1044,8 +1061,17 @@ export class UnitOfWork {
 
     this.deletedObjects = new ArrayCollection;
     this.transactions   = {};
-    this.afterCommit    = [];
 
     return Promise.resolve();
+  }
+
+  /**
+   * Mark everything as clean, empty transactions and empty after commits.
+   *
+   * @returns {UnitOfWork}
+   */
+  public clean(): Promise<void> {
+    return this.cleanObjectsAndTransactions()
+      .then(() => this.cleanAfterCommit());
   }
 }

--- a/src/UnitOfWork.ts
+++ b/src/UnitOfWork.ts
@@ -1036,7 +1036,7 @@ export class UnitOfWork {
    *
    * @returns {UnitOfWork}
    */
-  public clean(): UnitOfWork {
+  public clean(): Promise<void> {
     this.newObjects.each(created => this.registerClean(created));
     this.dirtyObjects.each(updated => this.registerClean(updated));
     this.relationshipsChangedObjects.each(changed => this.registerClean(changed));
@@ -1046,6 +1046,6 @@ export class UnitOfWork {
     this.transactions   = {};
     this.afterCommit    = [];
 
-    return this;
+    return Promise.resolve();
   }
 }


### PR DESCRIPTION
It appears the `UnitOfWork` due to a bug gives a dirty scope to the `lifecylebacks` *after* methods.
The fix consist in correcting the order in which things happen.

This fix might introduce a specific behavior : If `skipClean` is set to true then the lifecylebacks after methods won't be run because the `UnitOfWork` should not give it's scope if it's in a dirty state.