### PR TITLE
Fix/foreign policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",
   "scripts": {
-    "test": "mocha dist/test/helper dist/test/unit/**",
+    "test": "mocha dist/test/helper dist/test/unit/** --timeout 15000",
     "dtest": "npm run build && npm run test",
     "build": "rm -rf ./dist && tsc && gulp build",
     "version": "conventional-changelog -p angular -i doc/CHANGELOG.md -s && git add -A doc/CHANGELOG.md",

--- a/src/SchemaBuilder.ts
+++ b/src/SchemaBuilder.ts
@@ -215,7 +215,14 @@ export class SchemaBuilder {
     return this;
   }
 
-  private buildDropForeignKeys(drop, code, spacing) {
+  /**
+   * Build foreign key creates.
+   *
+   * @param {{}}        drop
+   * @param {string[]}  code
+   * @param {function}  spacing
+   */
+  private buildDropForeignKeys(drop: Object, code: Array<string>, spacing: (change?: number)=>string) {
     const tableNames = Reflect.ownKeys(drop);
 
     if (!tableNames.length) {
@@ -236,8 +243,14 @@ export class SchemaBuilder {
     });
   }
 
-  // @todo check typings in all my changes.
-  private buildCreateForeignKeys(create, code, spacing) {
+  /**
+   * Build foreign key creates.
+   *
+   * @param {{}}        create
+   * @param {string[]}  code
+   * @param {function}  spacing
+   */
+  private buildCreateForeignKeys(create: Object, code: Array<string>, spacing: (change?: number)=>string) {
     const tableNames = Reflect.ownKeys(create);
 
     if (!tableNames.length) {
@@ -271,33 +284,6 @@ export class SchemaBuilder {
 
       spacing(-2);
       code.push(`${spacing()}});`);
-    });
-  }
-
-  /**
-   * Create a foreign key.
-   *
-   * @param {{}}       table
-   * @param {function} spacing
-   * @param {string[]} code
-   */
-  private buildCreateForeigssnKeys(table: {foreign: Array<any>}, spacing: (change?: number) => string, code: Array<string>): void {
-    table.foreign.forEach(foreign => {
-      let foreignCode = spacing();
-      foreignCode += `table.foreign(${JSON.stringify(foreign.columns).replace(/"/g, "'")})`;
-      foreignCode += `.references('${foreign.references}').inTable('${foreign.inTable}')`;
-
-      if (foreign.onDelete) {
-        foreignCode += `.onDelete('${foreign.onDelete}')`;
-      }
-
-      if (foreign.onUpdate) {
-        foreignCode += `.onUpdate('${foreign.onUpdate}')`;
-      }
-
-      foreignCode += ';';
-
-      code.push(foreignCode);
     });
   }
 

--- a/test/unit/Cleaner.spec.ts
+++ b/test/unit/Cleaner.spec.ts
@@ -16,26 +16,26 @@ describe('Cleaner', () => {
 
       const wetland = new Wetland({
         dataDirectory: `${tmpTestDir}/.data`,
-        stores       : {
+        stores: {
           defaultStore: {
-            client    : 'mysql',
+            client: 'mysql',
             connection: {
               database: 'wetland_test',
-              user    : 'root',
+              user: 'root',
               password: ''
             }
           }
         },
-        seed         : {
+        seed: {
           fixturesDirectory: path.join(fixturesDir, getType(bypassLifecyclehooks)),
-          clean            : true,
+          clean: true,
           bypassLifecyclehooks
         },
-        entities     : [User, Pet, Post]
+        entities: [User, Pet, Post]
       });
 
-      const seeder   = wetland.getSeeder();
-      const cleaner  = wetland.getCleaner();
+      const seeder = wetland.getSeeder();
+      const cleaner = wetland.getCleaner();
       const migrator = wetland.getMigrator();
 
       return migrator.devMigrations(false)
@@ -52,32 +52,32 @@ describe('Cleaner', () => {
 
       const wetland = new Wetland({
         dataDirectory: `${tmpTestDir}/.data`,
-        stores       : {
+        stores: {
           defaultStore: {
-            client          : 'sqlite3',
+            client: 'sqlite3',
             useNullAsDefault: true,
-            connection      : {
+            connection: {
               filename: `${tmpTestDir}/cleaner.sqlite`
             }
           }
         },
-        seed         : {
+        seed: {
           fixturesDirectory: path.join(fixturesDir, getType(bypassLifecyclehooks)),
-          clean            : true,
+          clean: true,
           bypassLifecyclehooks
         },
-        entities     : [User, Pet, Post]
+        entities: [User, Pet, Post]
       });
 
-      const seeder   = wetland.getSeeder();
-      const cleaner  = wetland.getCleaner();
+      const seeder = wetland.getSeeder();
+      const cleaner = wetland.getCleaner();
       const migrator = wetland.getMigrator();
 
       return migrator.devMigrations(false)
-      .then(() => seeder.seed())
-      .then(() => cleaner.clean())
-      .then(() => migrator.devMigrations(false))
-      .then(() => seeder.seed());
+        .then(() => seeder.seed())
+        .then(() => cleaner.clean())
+        .then(() => migrator.devMigrations(false))
+        .then(() => seeder.seed());
     });
   });
 });

--- a/test/unit/Cleaner.spec.ts
+++ b/test/unit/Cleaner.spec.ts
@@ -34,8 +34,8 @@ describe('Cleaner', () => {
         entities: [User, Pet, Post]
       });
 
-      const seeder = wetland.getSeeder();
-      const cleaner = wetland.getCleaner();
+      const seeder   = wetland.getSeeder();
+      const cleaner  = wetland.getCleaner();
       const migrator = wetland.getMigrator();
 
       return migrator.devMigrations(false)
@@ -69,8 +69,8 @@ describe('Cleaner', () => {
         entities: [User, Pet, Post]
       });
 
-      const seeder = wetland.getSeeder();
-      const cleaner = wetland.getCleaner();
+      const seeder   = wetland.getSeeder();
+      const cleaner  = wetland.getCleaner();
       const migrator = wetland.getMigrator();
 
       return migrator.devMigrations(false)

--- a/test/unit/SnapshotManager.spec.ts
+++ b/test/unit/SnapshotManager.spec.ts
@@ -50,6 +50,7 @@ describe('SnapshotManager', () => {
       assert.equal(sqlStatement[1], 'alter table `media` add constraint `media_offer_id_foreign` foreign key (`offer_id`) references `offer` (`id`) on delete cascade');
     });
   });
+
   describe('diff(jc): create join column', () => {
     it('Should be able to create a non null foreign key', () => {
       let oldMapping = getMapping([]),
@@ -63,8 +64,8 @@ describe('SnapshotManager', () => {
 
       let sqlStatement = schemaBuilder.process(diff).getSQL().split('\n');
 
-      assert.equal(sqlStatement[0], 'create table `publisher` (`id` int unsigned not null auto_increment primary key, `name` varchar(24) not null);');
-      assert.equal(sqlStatement[1], 'create table `book` (`id` int unsigned not null auto_increment primary key, `name` varchar(24) not null, `publisher_id` int unsigned not null);');
+      assert.equal(sqlStatement[1], 'create table `publisher` (`id` int unsigned not null auto_increment primary key, `name` varchar(24) not null);');
+      assert.equal(sqlStatement[0], 'create table `book` (`id` int unsigned not null auto_increment primary key, `name` varchar(24) not null, `publisher_id` int unsigned not null);');
     })
   });
 });


### PR DESCRIPTION
What's happening in this PR?

- All foreign key edits have been moved out of their tables.
- All keys to drop, are dropped at the start of the migration.
- All keys to create, are created at the end of the migration.
- Removed dependency tracking. This is no longer needed.
- Improved performance by skipping mock-instructions.

The reason this was _inline_ initially, is because sqlite doesn;'t allow you to create foreign keys after the fact. However, this approach was causing issues on _real_ databases and we don't support foreign keys for sqlite anyway.