### PR TITLE
🚧 only set primaryKey to result if column is a autoIncrement field

### DIFF
--- a/src/UnitOfWork.ts
+++ b/src/UnitOfWork.ts
@@ -833,6 +833,11 @@ export class UnitOfWork {
               return;
             }
 
+            let isAutoIncrement = mapping.getField(primaryKey).generatedValue === 'autoIncrement'
+            if(!isAutoIncrement) {
+              return;
+            }
+
             if (target.isEntityProxy) {
               target[primaryKey] = { _skipDirty: result[0] };
 


### PR DESCRIPTION
This PR tries to resolve #260 by only setting the value of the primary key if the field is actually an auto-increment. 

If it is not an auto-increment field we do not set it. 